### PR TITLE
create NAT gateways for private subnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# used for testing
+terraform.tfvars
+
+### https://raw.github.com/github/gitignore/abad92dac5a4306f72242dae3bca6e277bce3615/Terraform.gitignore
+
+# Compiled files
+*.tfstate
+*.tfstate.backup
+
+# Module directory
+.terraform/
+
+
+### https://raw.github.com/github/gitignore/abad92dac5a4306f72242dae3bca6e277bce3615/Global/Vim.gitignore
+
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags
+
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Module Input Variables
 It's generally preferable to keep `public_subnets`, `private_subnets`, and
 `azs` to lists of the same length.
 
+This module creates NAT Gateways in each public subnet and sets them as the
+default gateways for the corresponding private subnets.
+
 Usage
 -----
 


### PR DESCRIPTION
create a NAT gateway in each public subnet, create a route table with
the respective NAT gateway as its default route, associate the
appropriate route table with each private subnet

also adding a `.gitignore` to facilitate testing
